### PR TITLE
Add localization for Survival Analysis and Diagnostic Test modules

### DIFF
--- a/app3.R
+++ b/app3.R
@@ -2138,50 +2138,50 @@ tabPanel(title = i18n$t("tab_corr"), value = "Correlation Tests",
 ####-###-###-###-###-###-###-###-###
 # 7. 生存分析类----
 ####-###-###-###-###-###-###-###-###
-        tabPanel("Survival Analysis",
-                 tabsetPanel(
+        tabPanel(i18n$t("tab_surv"),
+                tabsetPanel(
                    
                    
                    ##===-===-===-===-===-===-===
                    ## 7.2 Log-rank Test (TrialSize)----
                    ##===-===-===-===-===-===-===
-                   tabPanel("Log-rank Test",
-                            h3("Two-Sample Survival Equality (TrialSize)"),
+                   tabPanel(i18n$t("surv_tab_logrank"),
+                            h3(i18n$t("surv_lr_title")),
                             fluidRow(
                               column(4,
-                                     numericInput("lr_alpha", span("Significance Level (alpha):", 
+                                     numericInput("lr_alpha", span(i18n$t("surv_lr_label_alpha"),
                                                   tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                          onclick = "alert('Type I error rate for the log-rank test. Typically set at 0.05 for a two-sided test.'); return false;")
                                      ),value = 0.05, min = 0.01, max = 0.1, step = 0.01),
-                                     numericInput("lr_beta", span("Beta (1 - Power):",
+                                     numericInput("lr_beta", span(i18n$t("surv_lr_label_beta"),
                                                   tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                          onclick = "alert('Probability of failing to detect a true difference (1 - power).'); return false;")
                                      ), value = 0.2, min = 0.01, max = 0.5, step = 0.01),
-                                     numericInput("lr_lam1", span("Hazard Rate for Control Group (λ1):", 
+                                     numericInput("lr_lam1", span(i18n$t("surv_lr_label_lam1"),
                                                   tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                          onclick = "alert('Event rate (hazard) in the control group. λ = log(2)/median survival time.'); return false;")
                                      ), value = 1, min = 0, step = 0.01),
-                                     numericInput("lr_lam2", span("Hazard Rate for Treatment Group (λ2):", 
+                                     numericInput("lr_lam2", span(i18n$t("surv_lr_label_lam2"),
                                                   tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                          onclick = "alert('Event rate (hazard) in the treatment group.'); return false;")
                                      ),value = 2, min = 0, step = 0.01),
-                                     numericInput("lr_k", span("Allocation Ratio (k = n1 / n2):",
+                                     numericInput("lr_k", span(i18n$t("surv_lr_label_k"),
                                                   tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                          onclick = "alert('Ratio of sample size in treatment group to control group.'); return false;")
                                      ), value = 1, min = 0.1, max = 10, step = 0.1),
-                                     numericInput("lr_ttotal", span("Total Study Duration (T_total):", 
+                                     numericInput("lr_ttotal", span(i18n$t("surv_lr_label_ttotal"),
                                                   tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                          onclick = "alert('Total time (in years) that the study will run, including accrual and follow-up.'); return false;")
                                      ), value = 3, min = 1, step = 0.1),
-                                     numericInput("lr_taccrual", span("Accrual Duration (T_accrual):", 
+                                     numericInput("lr_taccrual", span(i18n$t("surv_lr_label_taccrual"),
                                                   tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                          onclick = "alert('Time period (in years) during which participants are recruited into the study.'); return false;")
                                      ), value = 1, min = 0.5, step = 0.1),
-                                     numericInput("lr_gamma", span("Accrual Distribution Parameter (γ):", 
+                                     numericInput("lr_gamma", span(i18n$t("surv_lr_label_gamma"),
                                                   tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                          onclick = "alert('Rate of random censoring due to dropout or loss to follow-up.'); return false;")
                                      ), value = 0.00001, min = 0, step = 0.00001),
-                                     actionButton("lr_calculate", "Calculate")
+                                     actionButton("lr_calculate", i18n$t("btn_calc"))
                               ),
                               column(8,
                                      verbatimTextOutput("lr_result"),
@@ -2193,32 +2193,32 @@ tabPanel(title = i18n$t("tab_corr"), value = "Correlation Tests",
                    ##===-===-===-===-===-===-===
                    ## 7.3 Group Sequential (gsDesign) ----
                    ##===-===-===-===-===-===-===
-                   tabPanel("Group Sequential",
-                            h3("Group Sequential for Survival Data (gsDesign)"),
+                   tabPanel(i18n$t("surv_tab_gsd"),
+                            h3(i18n$t("surv_gsd_title")),
                             fluidRow(
                               column(4,
                                      
-                                     numericInput("gsd_alpha", span("Significance Level (α)", 
+                                     numericInput("gsd_alpha", span(i18n$t("surv_gsd_label_alpha"),
                                                                     tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                            onclick = "alert('Overall two-sided significance level for group sequential log-rank test.'); return false;")
                                      ),value = 0.025, min = 0, max = 1),
-                                     numericInput("gsd_power", span("Power (1-β)", 
+                                     numericInput("gsd_power", span(i18n$t("surv_gsd_label_power"),
                                                                     tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                            onclick = "alert('Probability of detecting a true hazard difference across interim analyses.'); return false;")
                                      ),value = 0.9, min = 0, max = 1),
-                                     numericInput("gsd_nlooks", span("Number of Looks (k)", 
+                                     numericInput("gsd_nlooks", span(i18n$t("surv_gsd_label_nlooks"),
                                                                      tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                             onclick = "alert('Number of planned interim analyses, including the final look.'); return false;")
                                      ), value = 3, min = 1),
-                                     numericInput("gsd_delta", span("Standardized Effect Size (δ)", 
+                                     numericInput("gsd_delta", span(i18n$t("surv_gsd_label_delta"),
                                                                     tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                            onclick = "alert('Effect size specified as the natural log of the hazard ratio (log(HR)).'); return false;")
                                      ), value = 0.5),
-                                     selectInput("gsd_sfu", span("Upper Bound Spending Function", 
+                                     selectInput("gsd_sfu", span(i18n$t("surv_gsd_label_sfu"),
                                                                  tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                         onclick = "alert('Choose the method to control Type I error boundary at interim analyses.\\n\\nOF = O\\'Brien-Fleming (conservative)\\nPocock = equal boundaries\\nHSD = Hwang-Shih-DeCani family'); return false;")
                                      ),choices = c("OF", "Pocock", "HSD")),
-                                     selectInput("gsd_sfl", span("Lower Bound Spending Function", 
+                                     selectInput("gsd_sfl", span(i18n$t("surv_gsd_label_sfl"),
                                                                  tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                         onclick = "alert('Choose method for futility bounds (stopping early for lack of efficacy).\\n\\nOF = O\\'Brien-Fleming\\nPocock = Pocock boundary\\nHSD = Hwang-Shih-DeCani'); return false;")
                                      ),choices = c("OF", "Pocock", "HSD")),
@@ -2234,27 +2234,27 @@ tabPanel(title = i18n$t("tab_corr"), value = "Correlation Tests",
                    ##===-===-===-===-===-===-===
                    ## 7.4 Cox Proportional Hazards (TrialSize) ----
                    ##===-===-===-===-===-===-===
-                   tabPanel("Cox PH",
-                            h3("Cox Proportional Hazards Sample Size (TrialSize)"),
+                   tabPanel(i18n$t("surv_tab_cox"),
+                            h3(i18n$t("surv_cox_title")),
                             fluidRow(
                               column(4,
-                                     numericInput("cox_alpha", span("Significance Level (α)", 
+                                     numericInput("cox_alpha", span(i18n$t("surv_cox_label_alpha"),
                                                                     tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                            onclick = "alert('Two-sided alpha for hypothesis testing in Cox regression. Typically 0.05.'); return false;")
                                      ), value = 0.05, min = 0, max = 1),
-                                     numericInput("cox_power", span("Power (1-β)", 
+                                     numericInput("cox_power", span(i18n$t("surv_cox_label_power"),
                                                                     tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                            onclick = "alert('Probability of detecting a true hazard ratio under Cox model.'); return false;")
                                      ),value = 0.8, min = 0, max = 1),
-                                     numericInput("cox_hr", span("Hazard Ratio (HR)", 
+                                     numericInput("cox_hr", span(i18n$t("surv_cox_label_hr"),
                                                                  tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                         onclick = "alert('Assumed true hazard ratio between two groups. HR < 1 indicates benefit.'); return false;")
                                      ),value = 1.5, min = 0),
-                                     numericInput("cox_p1", span("Proportion in Treatment Group 1", 
+                                     numericInput("cox_p1", span(i18n$t("surv_cox_label_p1"),
                                                                  tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                         onclick = "alert('Proportion of subjects in the treatment group (group 1).'); return false;")
                                      ), value = 0.5, min = 0, max = 1),
-                                     numericInput("cox_d", span("Probability of Observing Event", 
+                                     numericInput("cox_d", span(i18n$t("surv_cox_label_d"),
                                                                 tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                                                        onclick = "alert('Number of events required to detect the specified hazard ratio with given power and alpha.'); return false;")
                                      ), value = 0.8, min = 0, max = 1),
@@ -2271,48 +2271,48 @@ tabPanel(title = i18n$t("tab_corr"), value = "Correlation Tests",
 ####-###-###-###-###-###-###-###-###
 # 8. 诊断检验类----
 ####-###-###-###-###-###-###-###-###
-      tabPanel("Diagnostic Test",
+      tabPanel(i18n$t("tab_diag"),
          tabsetPanel(
            ##===-===-===-===-===-===-===
            ## 8.1 Diagnostic Test Sample Size----
            ##===-===-===-===-===-===-===
-           tabPanel("Diagnostic Test",
-                    h3("Diagnostic Test Sample Size (epiR)"),
+           tabPanel(i18n$t("tab_diag"),
+                    h3(i18n$t("diag_test_title")),
                     fluidRow(
                       column(4,
                              
                              numericInput("diag_test", span(
-                               "Test Performance (Sensitivity or Specificity, 0–1)",
+                               i18n$t("diag_label_test_perf"),
                                tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                       onclick = "alert('Expected value of sensitivity (Se) or specificity (Sp), depending on the parameter being estimated. Value should be between 0 and 1.'); return false;")
                              ), value = 0.9, min = 0, max = 1),
                              
                              selectInput("diag_type", span(
-                               "Parameter to Estimate",
+                               i18n$t("diag_label_type"),
                                tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                       onclick = "alert('Choose which test characteristic to estimate sample size for: Sensitivity (Se) or Specificity (Sp).'); return false;")
                              ), choices = c("Sensitivity (Se)" = "se", "Specificity (Sp)" = "sp")),
                              
                              numericInput("diag_py", span(
-                               "Prevalence (0–1)",
+                               i18n$t("diag_label_py"),
                                tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                       onclick = "alert('Expected prevalence of disease in the population. Used to determine number of diseased and non-diseased subjects.'); return false;")
                              ), value = 0.1, min = 0, max = 1),
                              
                              numericInput("diag_epsilon", span(
-                               "Margin of Error (ε)",
+                               i18n$t("diag_label_epsilon"),
                                tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                       onclick = "alert('Maximum acceptable margin of error for the estimated sensitivity or specificity.'); return false;")
                              ), value = 0.05, min = 0, max = 1),
                              
                              numericInput("diag_alpha", span(
-                               "Significance Level (α)",
+                               i18n$t("diag_label_alpha"),
                                tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                       onclick = "alert('Type I error rate for the confidence interval around Se or Sp. Typically 0.05.'); return false;")
                              ), value = 0.05, min = 0, max = 1),
                              
                              numericInput("diag_power", span(
-                               "Target Power",
+                               i18n$t("diag_label_power"),
                                tags$a(tags$i(class = "fa fa-question-circle"), href = "#",
                                       onclick = "alert('Desired probability of achieving the specified margin of error for Se or Sp. Typically 0.8 or 0.9.'); return false;")
                              ), value = 0.8, min = 0, max = 1)
@@ -2466,10 +2466,10 @@ server <- function(input, output, session) {
           tags$li("Non-Inferiority"),
           tags$li("Equivalence"),
           tags$li("Superiority"),
-          tags$li("Survival Analysis - Log-rank Test"),
-          tags$li("Survival Analysis - Group Sequential"),
-          tags$li("Survival Analysis - Cox PH"),
-          tags$li("Diagnostic Test")
+          tags$li(i18n$t("home_li_surv_logrank")),
+          tags$li(i18n$t("home_li_surv_gsd")),
+          tags$li(i18n$t("home_li_surv_cox")),
+          tags$li(i18n$t("home_li_diag_test"))
         ),
         tags$p(i18n$t("sidebar_home_p3")),
         tags$p(i18n$t("sidebar_home_p4"))
@@ -2540,19 +2540,19 @@ server <- function(input, output, session) {
       )
     } else if (input$myInnerTabs == "Survival Analysis") {
       tagList(
-        h4("Survival Analysis"),
-        tags$p("Provides sample size tools for survival data: Log-rank test, Group Sequential design, Cox model, etc."),
-        tags$p("Usage: Input statistical parameters such as hazard rates, allocation ratio, accrual time, and total duration. Click to calculate."),
-        tags$p("In the Group Sequential module, the plot displays critical Z-values (normal quantiles) on the y-axis against cumulative sample size or information fraction on the x-axis."),
-        tags$p("These boundaries indicate the significance thresholds at each interim look — if your Z-statistic exceeds the upper boundary, you can reject the null hypothesis early."),
-        tags$p("Questions? Visit the 'About & Help' tab.")
+        h4(i18n$t("sidebar_surv_h4")),
+        tags$p(i18n$t("sidebar_surv_p1")),
+        tags$p(i18n$t("sidebar_surv_p2")),
+        tags$p(i18n$t("sidebar_surv_p3")),
+        tags$p(i18n$t("sidebar_surv_p4")),
+        tags$p(i18n$t("sidebar_surv_p5"))
       )
     } else if (input$myInnerTabs == "Diagnostic Test") {
       tagList(
-        h4("Diagnostic Test"),
-        tags$p("This section calculates the required sample size for evaluating diagnostic test accuracy based on sensitivity or specificity."),
-        tags$p("Usage: Choose whether you're estimating sensitivity or specificity. Enter prevalence, desired precision (margin of error), alpha, and power. Click 'Calculate Sample Size'."),
-        tags$p("To learn more or troubleshoot, please go to the 'About & Help' tab.")
+        h4(i18n$t("sidebar_diag_h4")),
+        tags$p(i18n$t("sidebar_diag_p1")),
+        tags$p(i18n$t("sidebar_diag_p2")),
+        tags$p(i18n$t("sidebar_diag_p3"))
       )
     } else if (input$myInnerTabs == "About&Help") {
       tagList(

--- a/translations.json
+++ b/translations.json
@@ -1266,11 +1266,299 @@
    "cn": "期望均值差 (Δ)：",
    "jp": "期待平均差 (Δ):"
  },
- {
+  {
    "key": "common_label_alloc",
    "en": "Allocation ratio (n1/n2):",
    "cn": "样本量比 (n1/n2)：",
    "jp": "割付比 (n1/n2):"
- }
+  },
+  {
+   "key": "tab_surv",
+   "en": "Survival Analysis",
+   "cn": "生存分析",
+   "jp": "生存時間解析"
+  },
+  {
+   "key": "surv_tab_logrank",
+   "en": "Log-rank Test",
+   "cn": "Log-rank 检验",
+   "jp": "ログランク検定"
+  },
+  {
+   "key": "surv_tab_gsd",
+   "en": "Group Sequential",
+   "cn": "组序设计",
+   "jp": "逐次デザイン"
+  },
+  {
+   "key": "surv_tab_cox",
+   "en": "Cox PH",
+   "cn": "Cox 比例风险",
+   "jp": "Cox比例ハザード"
+  },
+  {
+   "key": "surv_lr_title",
+   "en": "Two-Sample Survival Equality (TrialSize)",
+   "cn": "双样本生存率相等检验 (TrialSize)",
+   "jp": "二標本生存率同等性検定 (TrialSize)"
+  },
+  {
+   "key": "surv_lr_label_alpha",
+   "en": "Significance Level (alpha):",
+   "cn": "显著性水平 (alpha)：",
+   "jp": "有意水準 (α)："
+  },
+  {
+   "key": "surv_lr_label_beta",
+   "en": "Beta (1 - Power):",
+   "cn": "β (1 - Power)：",
+   "jp": "β (1 - Power)："
+  },
+  {
+   "key": "surv_lr_label_lam1",
+   "en": "Hazard Rate for Control Group (λ1):",
+   "cn": "对照组危险率 (λ1)：",
+   "jp": "対照群ハザード率 (λ1)："
+  },
+  {
+   "key": "surv_lr_label_lam2",
+   "en": "Hazard Rate for Treatment Group (λ2):",
+   "cn": "治疗组危险率 (λ2)：",
+   "jp": "治療群ハザード率 (λ2)："
+  },
+  {
+   "key": "surv_lr_label_k",
+   "en": "Allocation Ratio (k = n1 / n2):",
+   "cn": "分配比例 (k = n1 / n2)：",
+   "jp": "割付比 (k = n1 / n2)："
+  },
+  {
+   "key": "surv_lr_label_ttotal",
+   "en": "Total Study Duration (T_total):",
+   "cn": "研究总时长 (T_total)：",
+   "jp": "総研究期間 (T_total)："
+  },
+  {
+   "key": "surv_lr_label_taccrual",
+   "en": "Accrual Duration (T_accrual):",
+   "cn": "入组时长 (T_accrual)：",
+   "jp": "登録期間 (T_accrual)："
+  },
+  {
+   "key": "surv_lr_label_gamma",
+   "en": "Accrual Distribution Parameter (γ):",
+   "cn": "入组分布参数 (γ)：",
+   "jp": "登録分布パラメータ (γ)："
+  },
+  {
+   "key": "surv_gsd_title",
+   "en": "Group Sequential for Survival Data (gsDesign)",
+   "cn": "生存数据组序设计 (gsDesign)",
+   "jp": "生存データ逐次デザイン (gsDesign)"
+  },
+  {
+   "key": "surv_gsd_label_alpha",
+   "en": "Significance Level (α)",
+   "cn": "显著性水平 (α)",
+   "jp": "有意水準 (α)"
+  },
+  {
+   "key": "surv_gsd_label_power",
+   "en": "Power (1-β)",
+   "cn": "检验功效 (1-β)",
+   "jp": "検出力 (1-β)"
+  },
+  {
+   "key": "surv_gsd_label_nlooks",
+   "en": "Number of Looks (k)",
+   "cn": "中期分析次数 (k)",
+   "jp": "中間解析回数 (k)"
+  },
+  {
+   "key": "surv_gsd_label_delta",
+   "en": "Standardized Effect Size (δ)",
+   "cn": "标准化效应大小 (δ)",
+   "jp": "標準化効果量 (δ)"
+  },
+  {
+   "key": "surv_gsd_label_sfu",
+   "en": "Upper Bound Spending Function",
+   "cn": "上界花费函数",
+   "jp": "上限スぺンディング関数"
+  },
+  {
+   "key": "surv_gsd_label_sfl",
+   "en": "Lower Bound Spending Function",
+   "cn": "下界花费函数",
+   "jp": "下限スぺンディング関数"
+  },
+  {
+   "key": "surv_cox_title",
+   "en": "Cox Proportional Hazards Sample Size (TrialSize)",
+   "cn": "Cox比例风险样本量 (TrialSize)",
+   "jp": "Cox比例ハザードサンプルサイズ (TrialSize)"
+  },
+  {
+   "key": "surv_cox_label_alpha",
+   "en": "Significance Level (α)",
+   "cn": "显著性水平 (α)",
+   "jp": "有意水準 (α)"
+  },
+  {
+   "key": "surv_cox_label_power",
+   "en": "Power (1-β)",
+   "cn": "检验功效 (1-β)",
+   "jp": "検出力 (1-β)"
+  },
+  {
+   "key": "surv_cox_label_hr",
+   "en": "Hazard Ratio (HR)",
+   "cn": "风险比 (HR)",
+   "jp": "ハザード比 (HR)"
+  },
+  {
+   "key": "surv_cox_label_p1",
+   "en": "Proportion in Treatment Group 1",
+   "cn": "治疗组1比例",
+   "jp": "治療群1の割合"
+  },
+  {
+   "key": "surv_cox_label_d",
+   "en": "Probability of Observing Event",
+   "cn": "观察事件的概率",
+   "jp": "イベント観察確率"
+  },
+  {
+   "key": "tab_diag",
+   "en": "Diagnostic Test",
+   "cn": "诊断检验",
+   "jp": "診断テスト"
+  },
+  {
+   "key": "diag_test_title",
+   "en": "Diagnostic Test Sample Size (epiR)",
+   "cn": "诊断检验样本量 (epiR)",
+   "jp": "診断テストサンプルサイズ (epiR)"
+  },
+  {
+   "key": "diag_label_test_perf",
+   "en": "Test Performance (Sensitivity or Specificity, 0–1)",
+   "cn": "检验性能（灵敏度或特异度，0-1）",
+   "jp": "検査性能（感度または特異度，0〜1）"
+  },
+  {
+   "key": "diag_label_type",
+   "en": "Parameter to Estimate",
+   "cn": "估计参数",
+   "jp": "推定する指標"
+  },
+  {
+   "key": "diag_label_py",
+   "en": "Prevalence (0–1)",
+   "cn": "患病率 (0-1)",
+   "jp": "有病率 (0〜1)"
+  },
+  {
+   "key": "diag_label_epsilon",
+   "en": "Margin of Error (ε)",
+   "cn": "误差容限 (ε)",
+   "jp": "許容誤差 (ε)"
+  },
+  {
+   "key": "diag_label_alpha",
+   "en": "Significance Level (α)",
+   "cn": "显著性水平 (α)",
+   "jp": "有意水準 (α)"
+  },
+  {
+   "key": "diag_label_power",
+   "en": "Target Power",
+   "cn": "目标功效",
+   "jp": "目標検出力"
+  },
+  {
+   "key": "sidebar_surv_h4",
+   "en": "Survival Analysis",
+   "cn": "生存分析",
+   "jp": "生存時間解析"
+  },
+  {
+   "key": "sidebar_surv_p1",
+   "en": "Provides sample size tools for survival data: Log-rank test, Group Sequential design, Cox model, etc.",
+   "cn": "本模块提供生存资料的样本量工具，包含Log-rank检验、组序设计、Cox模型等。",
+   "jp": "このモジュールでは、ログランク検定、逐次デザイン、Coxモデルなど、生存データのサンプルサイズ計算を行います。"
+  },
+  {
+   "key": "sidebar_surv_p2",
+   "en": "Usage: Input statistical parameters such as hazard rates, allocation ratio, accrual time, and total duration. Click to calculate.",
+   "cn": "使用方法：输入危险率、分配比、入组时间及研究总时间等统计参数后点击计算。",
+   "jp": "使い方：ハザード率、割付比、登録期間、総期間などの統計量を入力して計算します。"
+  },
+  {
+   "key": "sidebar_surv_p3",
+   "en": "In the Group Sequential module, the plot displays critical Z-values (normal quantiles) on the y-axis against cumulative sample size or information fraction on the x-axis.",
+   "cn": "在组序模块中，图中纵轴为关键Z值，横轴为累计样本量或信息比例。",
+   "jp": "逐次解析モジュールでは、縦軸に臨界Z値（正規分位数）、横軸に累積サンプルサイズまたは情報比を表示します。"
+  },
+  {
+   "key": "sidebar_surv_p4",
+   "en": "These boundaries indicate the significance thresholds at each interim look — if your Z-statistic exceeds the upper boundary, you can reject the null hypothesis early.",
+   "cn": "这些界值指示各中期分析的显著性阈值—若统计量超过上界即可提前拒绝零假设。",
+   "jp": "これらの境界は各中間解析の有意水準を示します。Z統計が上限を超えれば早期に帰無仮説を棄却できます。"
+  },
+  {
+   "key": "sidebar_surv_p5",
+   "en": "Questions? Visit the 'About & Help' tab.",
+   "cn": "如有疑问，请查看‘关于和帮助’标签。",
+   "jp": "不明点は「About & Help」タブをご覧ください。"
+  },
+  {
+   "key": "sidebar_diag_h4",
+   "en": "Diagnostic Test",
+   "cn": "诊断检验",
+   "jp": "診断テスト"
+  },
+  {
+   "key": "sidebar_diag_p1",
+   "en": "This section calculates the required sample size for evaluating diagnostic test accuracy based on sensitivity or specificity.",
+   "cn": "该部分根据灵敏度或特异度计算评估诊断试验准确性的所需样本量。",
+   "jp": "このセクションでは感度または特異度に基づき診断テストの精度評価に必要なサンプルサイズを算出します。"
+  },
+  {
+   "key": "sidebar_diag_p2",
+   "en": "Usage: Choose whether you're estimating sensitivity or specificity. Enter prevalence, desired precision (margin of error), alpha, and power. Click 'Calculate Sample Size'.",
+   "cn": "使用方法：选择要估计敏感度还是特异度，输入患病率、允许误差、α和功效后点击‘计算样本量’。",
+   "jp": "使い方：感度か特異度を選択し、有病率、許容誤差、α、検出力を入力して『サンプルサイズ計算』をクリックします。"
+  },
+  {
+   "key": "sidebar_diag_p3",
+   "en": "To learn more or troubleshoot, please go to the 'About & Help' tab.",
+   "cn": "了解更多或排除故障，请访问‘关于和帮助’。",
+   "jp": "詳細やトラブルシュートは「About & Help」タブへ。"
+  },
+  {
+   "key": "home_li_surv_logrank",
+   "en": "Survival Analysis - Log-rank Test",
+   "cn": "生存分析 - Log-rank检验",
+   "jp": "生存解析 - ログランク検定"
+  },
+  {
+   "key": "home_li_surv_gsd",
+   "en": "Survival Analysis - Group Sequential",
+   "cn": "生存分析 - 组序设计",
+   "jp": "生存解析 - 逐次デザイン"
+  },
+  {
+   "key": "home_li_surv_cox",
+   "en": "Survival Analysis - Cox PH",
+   "cn": "生存分析 - Cox PH",
+   "jp": "生存解析 - Cox PH"
+  },
+  {
+   "key": "home_li_diag_test",
+   "en": "Diagnostic Test",
+   "cn": "诊断检验",
+   "jp": "診断テスト"
+  }
 ]
 }


### PR DESCRIPTION
## Summary
- internationalize Survival Analysis and Diagnostic Test tabs
- add translation keys and Chinese/Japanese text
- localize sidebar instructions and input labels

## Testing
- `python3 - <<'PY'
import re, json
text=open('translations.json').read()
text=re.sub(r'/\*.*?\*/', '', text, flags=re.S)
text=re.sub(r'//.*', '', text)
text=re.sub(r',\s*]', ']', text)
json.loads(text)
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6845484361e4832ba1276730e29c099b